### PR TITLE
Carthage Support and PDFImageView sizing enhancments.

### DIFF
--- a/Xcode/PDFImage.xcodeproj/xcshareddata/xcschemes/PDFImage.xcscheme
+++ b/Xcode/PDFImage.xcodeproj/xcshareddata/xcschemes/PDFImage.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C340C0D719C07FB000431A7D"
+               BuildableName = "PDFImage.framework"
+               BlueprintName = "PDFImage"
+               ReferencedContainer = "container:PDFImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C340C0D719C07FB000431A7D"
+            BuildableName = "PDFImage.framework"
+            BlueprintName = "PDFImage"
+            ReferencedContainer = "container:PDFImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C340C0D719C07FB000431A7D"
+            BuildableName = "PDFImage.framework"
+            BlueprintName = "PDFImage"
+            ReferencedContainer = "container:PDFImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Xcode/PDFImage/PDFImageView.h
+++ b/Xcode/PDFImage/PDFImageView.h
@@ -31,6 +31,8 @@
 
 @interface PDFImageView : UIView
 
+- (instancetype)initWithImage:(PDFImage *)image;
+
 @property (nonatomic, strong) PDFImage *image;
 @property (nonatomic, copy) UIColor *tintColor;
 

--- a/Xcode/PDFImage/PDFImageView.m
+++ b/Xcode/PDFImage/PDFImageView.m
@@ -109,9 +109,9 @@
 	self.options.scale = newWindow.screen.scale;
 }
 
-- (void)sizeToFit
+- (CGSize)sizeThatFits:(CGSize)size
 {
-	self.bounds = CGRectMake(0, 0, self.image.size.width, self.image.size.height);
+	return self.image.size;
 }
 
 + (Class)layerClass

--- a/Xcode/PDFImage/PDFImageView.m
+++ b/Xcode/PDFImage/PDFImageView.m
@@ -61,6 +61,17 @@
 	return self;
 }
 
+- (instancetype)initWithImage:(PDFImage *)image {
+	self = [self initWithFrame:CGRectMake(0, 0, image.size.width, image.size.height)];
+
+	if (self != nil)
+	{
+		self.image = image;
+	}
+
+	return self;
+}
+
 #pragma mark -
 #pragma mark Super
 
@@ -95,6 +106,11 @@
 	//	Set the scale to that of the window's screen
 	//	The scale would only change if the image view is added to an external UIScreen
 	self.options.scale = newWindow.screen.scale;
+}
+
+- (void)sizeToFit
+{
+	self.bounds = CGRectMake(0, 0, self.image.size.width, self.image.size.height);
 }
 
 + (Class)layerClass

--- a/Xcode/PDFImage/PDFImageView.m
+++ b/Xcode/PDFImage/PDFImageView.m
@@ -61,7 +61,8 @@
 	return self;
 }
 
-- (instancetype)initWithImage:(PDFImage *)image {
+- (instancetype)initWithImage:(PDFImage *)image
+{
 	self = [self initWithFrame:CGRectMake(0, 0, image.size.width, image.size.height)];
 
 	if (self != nil)


### PR DESCRIPTION
* Makes PDFImage compatible with Carthage by "sharing" the existing Xcode build Scheme
* Adds `PDFImageView +initWithImage:` convenience intalizer that sets the frame based on the underlying document's size.
* Implements `PDFImageView  -sizeToFit` to resize the bounds based on the underlying document size.
* Both of these additions nicely mirror `UIImageView`.

Before the convenience intializer.

``` swift
if let iconName = viewModel.iconName, iconImage = PDFImage(named: iconName) {
    let newIconView = PDFImageView(frame: CGRect(x: 0, y: 0, width: iconImage.size.width, height: iconImage.size.height))
    newIconView.image = iconImage
    newIconView.contentMode = .ScaleAspectFit
    iconView = newIconView
}
```

After the convenience intaizlier.

``` swift
if let iconName = viewModel.iconName, iconImage = PDFImage(named: iconName) {
    let newIconView = PDFImageView(image: iconImage)
    newIconView.contentMode = .ScaleAspectFit
    iconView = newIconView
}
```

Hope you think this patch makes a useful addition to the framework. Open to any feedback you have.